### PR TITLE
BE: [Feature] Filter by timestamp

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -137,6 +137,8 @@ paths:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/pageSize'
         - $ref: '#/components/parameters/sorting'
+        - $ref: '#/components/parameters/fromCreateTimestamp'
+        - $ref: '#/components/parameters/toCreateTimestamp'
       responses:
         '200':
           description: Get all users information successfully (with pagination metadata).
@@ -470,6 +472,10 @@ paths:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/pageSize'
         - $ref: '#/components/parameters/sorting'
+        - $ref: '#/components/parameters/fromCreateTimestamp'
+        - $ref: '#/components/parameters/toCreateTimestamp'
+        - $ref: '#/components/parameters/fromDeleteTimestamp'
+        - $ref: '#/components/parameters/toDeleteTimestamp'
       responses:
         '200':
           description:
@@ -1008,6 +1014,42 @@ components:
         items:
           type: string
           default: createTimestamp:desc
+    fromCreateTimestamp:
+      name: fromCreateTimestamp
+      in: query
+      description: Every items created after this timestamp will be returned
+      example: 2021-01-01T00:00:00Z
+      required: false
+      schema:
+        type: string
+        format: date-time
+    toCreateTimestamp:
+      name: toCreateTimestamp
+      in: query
+      description: Every items created before this timestamp will be returned
+      example: 2021-01-01T00:00:00Z
+      required: false
+      schema:
+        type: string
+        format: date-time
+    fromDeleteTimestamp:
+      name: fromDeleteTimestamp
+      in: query
+      description: Every items deleted after this timestamp will be returned
+      example: 2021-01-01T00:00:00Z
+      required: false
+      schema:
+        type: string
+        format: date-time
+    toDeleteTimestamp:
+      name: toDeleteTimestamp
+      in: query
+      description: Every items deleted before this timestamp will be returned
+      example: 2021-01-01T00:00:00Z
+      required: false
+      schema:
+        type: string
+        format: date-time
   securitySchemes:
     JWT:
       type: http

--- a/src/base/common/dtos/common-query.dto.ts
+++ b/src/base/common/dtos/common-query.dto.ts
@@ -7,6 +7,10 @@ export const commonQueryDto = z.object({
   page: z.coerce.number().int().positive().catch(1).default(1),
   pageSize: z.coerce.number().int().positive().catch(10).default(10),
   deleted: z.boolean().default(false).catch(false),
+  fromCreateTimestamp: z.coerce.date().optional(),
+  toCreateTimestamp: z.coerce.date().optional(),
+  fromDeleteTimestamp: z.coerce.date().optional(),
+  toDeleteTimestamp: z.coerce.date().optional(),
 });
 
 export type CommonQueryDto = z.infer<typeof commonQueryDto>;

--- a/src/modules/user/services/user.service.ts
+++ b/src/modules/user/services/user.service.ts
@@ -26,9 +26,23 @@ class UserService {
     pageSize,
     sorting,
     deleted,
+    fromCreateTimestamp,
+    toCreateTimestamp,
+    fromDeleteTimestamp,
+    toDeleteTimestamp,
   }: UserQueryDto): Promise<SuccessResponseBody<UserDto[] | DeletedUserDto[]>> {
     const filter: RootFilterQuery<User> = {
-      deleteTimestamp: deleted ? { $ne: null } : null,
+      deleteTimestamp: !deleted
+        ? null
+        : {
+            $ne: null,
+            ...(fromDeleteTimestamp && { $gte: fromDeleteTimestamp }),
+            ...(toDeleteTimestamp && { $lte: toDeleteTimestamp }),
+          },
+      createTimestamp: {
+        ...(fromCreateTimestamp && { $gte: fromCreateTimestamp }),
+        ...(toCreateTimestamp && { $lte: toCreateTimestamp }),
+      },
     };
 
     const query = UserModel.find(filter)


### PR DESCRIPTION
# 1. TODO List:
- Sau khi PR này được merge, tiến hành pull `dev` về và merge vào nhánh của mình
- Thêm phần xử lý filter timestamp ở service, theo hướng dẫn ở phần 3
- Thêm các query params (nhắc đến ở phần 2) vào các route get all & get all deleted, theo hướng dẫn ở phần 4

# 2. Query params:
Các field sau được thêm vào `commonQueryDto`: 
- `fromCreateTimestamp`: Nhận vào một string date, lọc ra các item có `createTimestamp` **lớn hơn hoặc bằng** timestamp chỉ định.
- `toCreateTimestamp`: Nhận vào một string date, lọc ra các item có `createTimestamp` **nhỏ hơn hoặc bằng** timestamp chỉ định
- `fromDeleteTimestamp`: Nhận vào một string date, lọc ra các item có `deleteTimestamp` **lớn hơn hoặc bằng** timestamp chỉ định
- `fromDeleteTimestamp`: Nhận vào một string date, lọc ra các item có `deleteTimestamp` **nhỏ hơn hoặc bằng** timestamp chỉ định
> ⚠️ Chú ý: 
> - Format của string date tuân theo tiêu chuẩn của [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) (còn được gọi là ISO 8601)
> - Múi giờ của timestamp luôn là **UTC+00:00**
> - Hai field `fromDeleteTimestamp` & `toDeleteTimestamp` chỉ áp dụng với các route get all deleted

# 3. Cách xử lý filter timestamp ở service:
> ## ⚠️Update (06/03/2025): Phần này đã được sửa lại theo PR #26 

Trong hàm `findAllAndCount` (hoặc hàm được gắn với route get all), sửa biến `filter` như sau:
```ts
const filter: RootFilterQuery<User> = {
  deleteTimestamp: !deleted
    ? null
    : {
        $ne: null,
        ...(fromDeleteTimestamp && { $gte: fromDeleteTimestamp }),
        ...(toDeleteTimestamp && { $lte: toDeleteTimestamp }),
      },
};

if (fromCreateTimestamp || toCreateTimestamp) {
  filter.createTimestamp = {
    ...(fromCreateTimestamp && { $gte: fromCreateTimestamp }),
    ...(toCreateTimestamp && { $lte: toCreateTimestamp }),
  };
}
```

# 4. Cách thêm các query params ở trên vào các route get all/get all deleted trong Swagger:
- Các query params đã được định nghĩa sẵn, chỉ cần mang ra sử dụng ở các route get all (deleted) tương ứng
- Module `user` đã được thêm vào sẵn, các module còn lại hiện chưa được thêm
- Đối với các route get all:
```diff
      parameters:
        - $ref: '#/components/parameters/page'
        - $ref: '#/components/parameters/pageSize'
        - $ref: '#/components/parameters/sorting'
+       - $ref: '#/components/parameters/fromCreateTimestamp'
+       - $ref: '#/components/parameters/toCreateTimestamp'
```
> ⚠️Chú ý: Do route get all sẽ tự động bỏ qua `fromDeleteTimestamp` & `toDeleteTimestamp` nên 2 field đó không xuất hiện ở đây 
- Đối với các route get all deleted:
```diff
      parameters:
        - $ref: '#/components/parameters/page'
        - $ref: '#/components/parameters/pageSize'
        - $ref: '#/components/parameters/sorting'
+       - $ref: '#/components/parameters/fromDeleteTimestamp'
+       - $ref: '#/components/parameters/toDeleteTimestamp'
+       - $ref: '#/components/parameters/fromDeleteTimestamp'
+       - $ref: '#/components/parameters/toDeleteTimestamp'
```

cc: @tronghghe172557, @vtrthu, @Gentle226, @Baovu2003, @anhnnhe176642 