### PR TITLE
BE: [Fix] createTimestamp filter in service

### DIFF
--- a/src/modules/user/services/user.service.ts
+++ b/src/modules/user/services/user.service.ts
@@ -39,11 +39,14 @@ class UserService {
             ...(fromDeleteTimestamp && { $gte: fromDeleteTimestamp }),
             ...(toDeleteTimestamp && { $lte: toDeleteTimestamp }),
           },
-      createTimestamp: {
+    };
+
+    if (fromCreateTimestamp || toCreateTimestamp) {
+      filter.createTimestamp = {
         ...(fromCreateTimestamp && { $gte: fromCreateTimestamp }),
         ...(toCreateTimestamp && { $lte: toCreateTimestamp }),
-      },
-    };
+      };
+    }
 
     const query = UserModel.find(filter)
       .limit(pageSize)


### PR DESCRIPTION
Sửa lại phần filter cho field `createTimestamp` trong service (phần 3 của PR #24):
```ts
const filter: RootFilterQuery<User> = {
  deleteTimestamp: !deleted
    ? null
    : {
        $ne: null,
        ...(fromDeleteTimestamp && { $gte: fromDeleteTimestamp }),
        ...(toDeleteTimestamp && { $lte: toDeleteTimestamp }),
      },
};

if (fromCreateTimestamp || toCreateTimestamp) {
  filter.createTimestamp = {
    ...(fromCreateTimestamp && { $gte: fromCreateTimestamp }),
    ...(toCreateTimestamp && { $lte: toCreateTimestamp }),
  };
}
```